### PR TITLE
Adds support for blake2x by allowing max_depth 0

### DIFF
--- a/blake2b/src/lib.rs
+++ b/blake2b/src/lib.rs
@@ -287,10 +287,9 @@ impl Params {
         self
     }
 
-    /// From 1 (the default, meaning sequential) to 255 (meaning unlimited).
+    /// From 0, through 1 (the default, meaning sequential) to 255 (meaning unlimited).
     #[inline]
     pub fn max_depth(&mut self, depth: u8) -> &mut Self {
-        assert!(depth != 0, "Bad max depth: {}", depth);
         self.max_depth = depth;
         self
     }

--- a/blake2b/src/lib.rs
+++ b/blake2b/src/lib.rs
@@ -287,7 +287,7 @@ impl Params {
         self
     }
 
-    /// From 0, through 1 (the default, meaning sequential) to 255 (meaning unlimited).
+    /// From 0 (meaning BLAKE2X B2 hashes), through 1 (the default, meaning sequential) to 255 (meaning unlimited).
     #[inline]
     pub fn max_depth(&mut self, depth: u8) -> &mut Self {
         self.max_depth = depth;

--- a/blake2b/src/test.rs
+++ b/blake2b/src/test.rs
@@ -172,8 +172,7 @@ fn test_long_personal_panics() {
 }
 
 #[test]
-#[should_panic]
-fn test_zero_max_depth_panics() {
+fn test_zero_max_depth_supported() {
     Params::new().max_depth(0);
 }
 

--- a/blake2s/src/lib.rs
+++ b/blake2s/src/lib.rs
@@ -278,10 +278,9 @@ impl Params {
         self
     }
 
-    /// From 1 (the default, meaning sequential) to 255 (meaning unlimited).
+    /// From 0, through 1 (the default, meaning sequential) to 255 (meaning unlimited).
     #[inline]
     pub fn max_depth(&mut self, depth: u8) -> &mut Self {
-        assert!(depth != 0, "Bad max depth: {}", depth);
         self.max_depth = depth;
         self
     }

--- a/blake2s/src/lib.rs
+++ b/blake2s/src/lib.rs
@@ -278,7 +278,7 @@ impl Params {
         self
     }
 
-    /// From 0, through 1 (the default, meaning sequential) to 255 (meaning unlimited).
+    /// From 0 (meaning BLAKE2X B2 hashes), through 1 (the default, meaning sequential) to 255 (meaning unlimited).
     #[inline]
     pub fn max_depth(&mut self, depth: u8) -> &mut Self {
         self.max_depth = depth;

--- a/blake2s/src/test.rs
+++ b/blake2s/src/test.rs
@@ -168,8 +168,7 @@ fn test_long_personal_panics() {
 }
 
 #[test]
-#[should_panic]
-fn test_zero_max_depth_panics() {
+fn test_zero_max_depth_supported() {
     Params::new().max_depth(0);
 }
 

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -149,3 +149,110 @@ fn blake2sp_vectors() {
     // count.
     assert_eq!(512, test_num);
 }
+
+fn blake2x_test<F: Fn(&[u8], &[u8], u64) -> Vec<u8>, F2: Fn(&[u8], u64, usize) -> Vec<u8>>(h0_hasher: F, b2_hasher: F2, variant_hash_length: usize, variant_name: &str) {
+    let mut test_num = 0u64;
+    for case in TEST_CASES.iter() {
+        if &case.hash == variant_name {
+            test_num += 1;
+
+            let input_bytes = hex::decode(&case.in_).unwrap();
+            let key = if !case.key.is_empty() {
+                hex::decode(&case.key).unwrap()
+            } else {
+                vec![]
+            };
+
+            let output_length = case.out.len()/2;
+            let encoded_output_length = (((output_length & ((1 << 8) - 1)) << 32) | ((output_length >> 8) << 40)) as u64;
+            let h0 = h0_hasher(&input_bytes, &key, encoded_output_length);
+
+            let num_hashes = (output_length + variant_hash_length - 1)/variant_hash_length;
+            let mut buf = vec![];
+            for i in 0..num_hashes {
+                let hash_length = {
+                    if i == (num_hashes - 1) && (output_length % variant_hash_length) != 0 {
+                        output_length % variant_hash_length
+                    } else {
+                        variant_hash_length
+                    }
+                };
+
+                let b2_out = b2_hasher(&h0, (i as u64) | encoded_output_length, hash_length);
+                buf.extend_from_slice(&b2_out);
+            }
+            assert_eq!(case.out, hex::encode(&buf[..output_length]));
+        }
+    }
+
+    // Make sure we don't accidentally skip all the tests somehow. If the
+    // number of test vectors changes in the future, we'll need to update this
+    // count.
+    assert_eq!(512, test_num);
+}
+
+#[test]
+fn blake2xs_vectors() {
+    let blake2xs_h0_hasher = |input_bytes: &[u8], key: &[u8], encoded_output_length: u64| -> Vec<u8> {
+        let mut params = blake2s_simd::Params::new();
+        if key.len() > 0 {
+            params.key(key);
+        }
+        params
+            .hash_length(32)
+            .node_offset(encoded_output_length);
+        let mut state = params.to_state();
+        state.update(&input_bytes);
+        let h0 = state.finalize().as_ref().to_vec();
+        h0
+    };
+    let blake2xs_b2_hasher = |input_bytes: &[u8], encoded_output_length: u64, hash_length: usize| -> Vec<u8> {
+        let mut params = blake2s_simd::Params::new();
+        params
+            .hash_length(hash_length)
+            .max_leaf_length(32)
+            .inner_hash_length(32)
+            .fanout(0)
+            .max_depth(0)
+            .node_offset(encoded_output_length);
+        let mut state = params.to_state();
+        state.update(&input_bytes);
+        let b2_out = state.finalize().as_ref().to_vec();
+        b2_out
+    };
+
+    blake2x_test(blake2xs_h0_hasher, blake2xs_b2_hasher, 32, "blake2xs");
+}
+
+#[test]
+fn blake2xb_vectors() {
+    let blake2xb_h0_hasher = |input_bytes: &[u8], key: &[u8], encoded_output_length: u64| -> Vec<u8> {
+        let mut params = blake2b_simd::Params::new();
+        if key.len() > 0 {
+            params.key(key);
+        }
+        params
+            .hash_length(64)
+            .node_offset(encoded_output_length);
+        let mut state = params.to_state();
+        state.update(&input_bytes);
+        let h0 = state.finalize().as_ref().to_vec();
+        h0
+    };
+    let blake2xb_b2_hasher = |input_bytes: &[u8], encoded_output_length: u64, hash_length: usize| -> Vec<u8> {
+        let mut params = blake2b_simd::Params::new();
+        params
+            .hash_length(hash_length)
+            .max_leaf_length(64)
+            .inner_hash_length(64)
+            .fanout(0)
+            .max_depth(0)
+            .node_offset(encoded_output_length);
+        let mut state = params.to_state();
+        state.update(&input_bytes);
+        let b2_out = state.finalize().as_ref().to_vec();
+        b2_out
+    };
+
+    blake2x_test(blake2xb_h0_hasher, blake2xb_b2_hasher, 64, "blake2xb");
+}

--- a/tests/vector_tests.rs
+++ b/tests/vector_tests.rs
@@ -150,7 +150,12 @@ fn blake2sp_vectors() {
     assert_eq!(512, test_num);
 }
 
-fn blake2x_test<F: Fn(&[u8], &[u8], u64) -> Vec<u8>, F2: Fn(&[u8], u64, usize) -> Vec<u8>>(h0_hasher: F, b2_hasher: F2, variant_hash_length: usize, variant_name: &str) {
+fn blake2x_test<F: Fn(&[u8], &[u8], u64) -> Vec<u8>, F2: Fn(&[u8], u64, usize) -> Vec<u8>>(
+    h0_hasher: F,
+    b2_hasher: F2,
+    variant_hash_length: usize,
+    variant_name: &str,
+) {
     let mut test_num = 0u64;
     for case in TEST_CASES.iter() {
         if &case.hash == variant_name {
@@ -163,23 +168,36 @@ fn blake2x_test<F: Fn(&[u8], &[u8], u64) -> Vec<u8>, F2: Fn(&[u8], u64, usize) -
                 vec![]
             };
 
-            let output_length = case.out.len()/2;
-            let encoded_output_length = (((output_length & ((1 << 8) - 1)) << 32) | ((output_length >> 8) << 40)) as u64;
-            let h0 = h0_hasher(&input_bytes, &key, encoded_output_length);
+            let output_length = case.out.len() / 2;
 
-            let num_hashes = (output_length + variant_hash_length - 1)/variant_hash_length;
+            // BLAKE2X divides the underlying hash node_offset into two parts - node_offset
+            // and xof_digest_length. This is the encoding of xof_digest_length in the
+            // correct position in the node_offset.
+            let combined_node_offset_xof_length = (output_length as u64) << 32;
+            let h0 = h0_hasher(&input_bytes, &key, combined_node_offset_xof_length);
+
             let mut buf = vec![];
-            for i in 0..num_hashes {
+            let mut b2_hash_index = 0;
+            while buf.len() < output_length {
                 let hash_length = {
-                    if i == (num_hashes - 1) && (output_length % variant_hash_length) != 0 {
+                    // Is this the last hash and the digest length doesn't divide the output
+                    // length?
+                    if output_length - buf.len() < variant_hash_length
+                        && (output_length % variant_hash_length) != 0
+                    {
                         output_length % variant_hash_length
                     } else {
                         variant_hash_length
                     }
                 };
 
-                let b2_out = b2_hasher(&h0, (i as u64) | encoded_output_length, hash_length);
+                let b2_out = b2_hasher(
+                    &h0,
+                    (b2_hash_index as u64) | combined_node_offset_xof_length,
+                    hash_length,
+                );
                 buf.extend_from_slice(&b2_out);
+                b2_hash_index += 1;
             }
             assert_eq!(case.out, hex::encode(&buf[..output_length]));
         }
@@ -193,66 +211,66 @@ fn blake2x_test<F: Fn(&[u8], &[u8], u64) -> Vec<u8>, F2: Fn(&[u8], u64, usize) -
 
 #[test]
 fn blake2xs_vectors() {
-    let blake2xs_h0_hasher = |input_bytes: &[u8], key: &[u8], encoded_output_length: u64| -> Vec<u8> {
-        let mut params = blake2s_simd::Params::new();
-        if key.len() > 0 {
-            params.key(key);
-        }
-        params
-            .hash_length(32)
-            .node_offset(encoded_output_length);
-        let mut state = params.to_state();
-        state.update(&input_bytes);
-        let h0 = state.finalize().as_ref().to_vec();
-        h0
-    };
-    let blake2xs_b2_hasher = |input_bytes: &[u8], encoded_output_length: u64, hash_length: usize| -> Vec<u8> {
-        let mut params = blake2s_simd::Params::new();
-        params
-            .hash_length(hash_length)
-            .max_leaf_length(32)
-            .inner_hash_length(32)
-            .fanout(0)
-            .max_depth(0)
-            .node_offset(encoded_output_length);
-        let mut state = params.to_state();
-        state.update(&input_bytes);
-        let b2_out = state.finalize().as_ref().to_vec();
-        b2_out
-    };
+    let blake2xs_h0_hasher =
+        |input_bytes: &[u8], key: &[u8], combined_node_offset_xof_length: u64| -> Vec<u8> {
+            let mut params = blake2s_simd::Params::new();
+            let h0 = params
+                .key(key)
+                .hash_length(32)
+                .node_offset(combined_node_offset_xof_length)
+                .hash(&input_bytes)
+                .as_bytes()
+                .to_vec();
+            h0
+        };
+    let blake2xs_b2_hasher =
+        |input_bytes: &[u8], combined_node_offset_xof_length: u64, hash_length: usize| -> Vec<u8> {
+            let mut params = blake2s_simd::Params::new();
+            let b2_out = params
+                .hash_length(hash_length)
+                .max_leaf_length(32)
+                .inner_hash_length(32)
+                .fanout(0)
+                .max_depth(0)
+                .node_offset(combined_node_offset_xof_length)
+                .hash(&input_bytes)
+                .as_bytes()
+                .to_vec();
+            b2_out
+        };
 
     blake2x_test(blake2xs_h0_hasher, blake2xs_b2_hasher, 32, "blake2xs");
 }
 
 #[test]
 fn blake2xb_vectors() {
-    let blake2xb_h0_hasher = |input_bytes: &[u8], key: &[u8], encoded_output_length: u64| -> Vec<u8> {
-        let mut params = blake2b_simd::Params::new();
-        if key.len() > 0 {
-            params.key(key);
-        }
-        params
-            .hash_length(64)
-            .node_offset(encoded_output_length);
-        let mut state = params.to_state();
-        state.update(&input_bytes);
-        let h0 = state.finalize().as_ref().to_vec();
-        h0
-    };
-    let blake2xb_b2_hasher = |input_bytes: &[u8], encoded_output_length: u64, hash_length: usize| -> Vec<u8> {
-        let mut params = blake2b_simd::Params::new();
-        params
-            .hash_length(hash_length)
-            .max_leaf_length(64)
-            .inner_hash_length(64)
-            .fanout(0)
-            .max_depth(0)
-            .node_offset(encoded_output_length);
-        let mut state = params.to_state();
-        state.update(&input_bytes);
-        let b2_out = state.finalize().as_ref().to_vec();
-        b2_out
-    };
+    let blake2xb_h0_hasher =
+        |input_bytes: &[u8], key: &[u8], combined_node_offset_xof_length: u64| -> Vec<u8> {
+            let mut params = blake2b_simd::Params::new();
+            let h0 = params
+                .key(key)
+                .hash_length(64)
+                .node_offset(combined_node_offset_xof_length)
+                .hash(&input_bytes)
+                .as_bytes()
+                .to_vec();
+            h0
+        };
+    let blake2xb_b2_hasher =
+        |input_bytes: &[u8], combined_node_offset_xof_length: u64, hash_length: usize| -> Vec<u8> {
+            let mut params = blake2b_simd::Params::new();
+            let b2_out = params
+                .hash_length(hash_length)
+                .max_leaf_length(64)
+                .inner_hash_length(64)
+                .fanout(0)
+                .max_depth(0)
+                .node_offset(combined_node_offset_xof_length)
+                .hash(&input_bytes)
+                .as_bytes()
+                .to_vec();
+            b2_out
+        };
 
     blake2x_test(blake2xb_h0_hasher, blake2xb_b2_hasher, 64, "blake2xb");
 }


### PR DESCRIPTION
This is required to support Blake2x (https://blake2.net/blake2x.pdf).

The PR also adds testing for blake2x using the reference implementation test vectors.