### PR TITLE
Update arrayvec dep to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 std = ["blake2b_simd/std", "blake2s_simd/std"]
 
 [dependencies]
-arrayvec = "0.4.10"
+arrayvec = "0.5.0"
 blake2b_simd = { path = "./blake2b", default-features = false }
 blake2s_simd = { path = "./blake2s", default-features = false }
 blake2-avx2-sneves = { path = "benches/blake2-avx2-sneves", optional = true }

--- a/benches/bench_multiprocess/Cargo.toml
+++ b/benches/bench_multiprocess/Cargo.toml
@@ -12,4 +12,4 @@ openssl = "0.10.23"
 libsodium-ffi = "0.1.17"
 blake2-avx2-sneves = { path = "../blake2-avx2-sneves" }
 page_size = "0.4.1"
-arrayvec = "0.4.10"
+arrayvec = "0.5.0"

--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -15,5 +15,5 @@ std = []
 
 [dependencies]
 arrayref = "0.3.5"
-arrayvec = { version = "0.4.10", default-features = false }
+arrayvec = { version = "0.5.0", default-features = false }
 constant_time_eq = "0.1.3"

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -15,5 +15,5 @@ std = []
 
 [dependencies]
 arrayref = "0.3.5"
-arrayvec = { version = "0.4.10", default-features = false }
+arrayvec = { version = "0.5.0", default-features = false }
 constant_time_eq = "0.1.3"


### PR DESCRIPTION
This updates the arrayvec dependency. No changes should be needed, but it changes the minimum Rust version required to Rust 1.36 (if that's not already a requirement).