### PR TITLE
Switch to subtle from constant_time_eq.

### DIFF
--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -22,4 +22,4 @@ uninline_portable = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.5.0", default-features = false }
-constant_time_eq = "0.1.3"
+subtle = "2.2.3"

--- a/blake2b/src/lib.rs
+++ b/blake2b/src/lib.rs
@@ -619,14 +619,16 @@ fn bytes_to_hex(bytes: &[u8]) -> HexString {
 /// This implementation is constant time, if the two hashes are the same length.
 impl PartialEq for Hash {
     fn eq(&self, other: &Hash) -> bool {
-        constant_time_eq::constant_time_eq(&self.as_bytes(), &other.as_bytes())
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other.as_bytes()).into()
     }
 }
 
 /// This implementation is constant time, if the slice is the same length as the hash.
 impl PartialEq<[u8]> for Hash {
     fn eq(&self, other: &[u8]) -> bool {
-        constant_time_eq::constant_time_eq(&self.as_bytes(), other)
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other).into()
     }
 }
 

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -17,4 +17,4 @@ std = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.5.0", default-features = false }
-constant_time_eq = "0.1.3"
+subtle = "2.2"

--- a/blake2s/src/lib.rs
+++ b/blake2s/src/lib.rs
@@ -611,14 +611,16 @@ fn bytes_to_hex(bytes: &[u8]) -> HexString {
 /// This implementation is constant time, if the two hashes are the same length.
 impl PartialEq for Hash {
     fn eq(&self, other: &Hash) -> bool {
-        constant_time_eq::constant_time_eq(&self.as_bytes(), &other.as_bytes())
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other.as_bytes()).into()
     }
 }
 
 /// This implementation is constant time, if the slice is the same length as the hash.
 impl PartialEq<[u8]> for Hash {
     fn eq(&self, other: &[u8]) -> bool {
-        constant_time_eq::constant_time_eq(&self.as_bytes(), other)
+        use subtle::ConstantTimeEq;
+        self.as_bytes().ct_eq(other).into()
     }
 }
 


### PR DESCRIPTION
This is useful in a Zcash-related context, where other Zcash libraries (jubjub,
bls12_381, etc.) already use subtle, so moving to the subtle crate means that
constant-time operations are consolidated into a single crate.