### PR TITLE
Refactor to use arrayvec 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 std = ["blake2b_simd/std", "blake2s_simd/std"]
 
 [dependencies]
-arrayvec = "0.5.0"
+arrayvec = "0.7.0"
 blake2b_simd = { path = "./blake2b", default-features = false }
 blake2s_simd = { path = "./blake2s", default-features = false }
 blake2-avx2-sneves = { path = "benches/blake2-avx2-sneves", optional = true }

--- a/benches/bench_multiprocess/Cargo.toml
+++ b/benches/bench_multiprocess/Cargo.toml
@@ -13,4 +13,4 @@ openssl = "0.10.23"
 libsodium-ffi = "0.1.17"
 blake2-avx2-sneves = { path = "../blake2-avx2-sneves" }
 page_size = "0.4.1"
-arrayvec = "0.5.0"
+arrayvec = "0.7.0"

--- a/benches/bench_multiprocess/src/main.rs
+++ b/benches/bench_multiprocess/src/main.rs
@@ -103,7 +103,7 @@ fn blake2s_hash() -> u128 {
 //     }
 //     let params = blake2b_simd::Params::new();
 //     bench(|| {
-//         let mut jobs = arrayvec::ArrayVec::<[_; blake2b_simd::many::MAX_DEGREE]>::new();
+//         let mut jobs = arrayvec::ArrayVec::<_, { blake2b_simd::many::MAX_DEGREE }>::new();
 //         for input in &mut inputs {
 //             let job = blake2b_simd::many::HashManyJob::new(&params, input.get());
 //             jobs.push(job);
@@ -129,7 +129,7 @@ fn blake2b_hash_many() -> u128 {
     }
     let params = blake2b_simd::Params::new();
     bench(|| {
-        let mut jobs = arrayvec::ArrayVec::<[_; blake2b_simd::many::MAX_DEGREE]>::new();
+        let mut jobs = arrayvec::ArrayVec::<_, { blake2b_simd::many::MAX_DEGREE }>::new();
         for input in &mut inputs {
             let job = blake2b_simd::many::HashManyJob::new(&params, input.get());
             jobs.push(job);
@@ -149,7 +149,7 @@ fn blake2s_hash_many() -> u128 {
     }
     let params = blake2s_simd::Params::new();
     bench(|| {
-        let mut jobs = arrayvec::ArrayVec::<[_; blake2s_simd::many::MAX_DEGREE]>::new();
+        let mut jobs = arrayvec::ArrayVec::<_, { blake2s_simd::many::MAX_DEGREE }>::new();
         for input in &mut inputs {
             let job = blake2s_simd::many::HashManyJob::new(&params, input.get());
             jobs.push(job);

--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -21,5 +21,5 @@ uninline_portable = []
 
 [dependencies]
 arrayref = "0.3.5"
-arrayvec = { version = "0.5.0", default-features = false }
+arrayvec = { version = "0.7.0", default-features = false }
 constant_time_eq = "0.1.3"

--- a/blake2b/src/blake2bp.rs
+++ b/blake2b/src/blake2bp.rs
@@ -488,7 +488,7 @@ pub(crate) mod test {
     // support of the real implementation. We need this because the official test vectors don't
     // include any inputs large enough to exercise all the branches in the buffering logic.
     fn blake2bp_reference(input: &[u8]) -> Hash {
-        let mut leaves = arrayvec::ArrayVec::<[_; DEGREE]>::new();
+        let mut leaves = arrayvec::ArrayVec::<_, DEGREE>::new();
         for leaf_index in 0..DEGREE {
             leaves.push(
                 crate::Params::new()

--- a/blake2b/src/guts.rs
+++ b/blake2b/src/guts.rs
@@ -444,13 +444,13 @@ mod test {
 
         let mut input_buffer = [0; 100 * BLOCKBYTES];
         paint_test_input(&mut input_buffer);
-        let mut inputs = ArrayVec::<[_; N]>::new();
+        let mut inputs = ArrayVec::<_, N>::new();
         for i in 0..N {
             inputs.push(&input_buffer[i..]);
         }
 
         exercise_cases(|stride, length, last_node, finalize, count| {
-            let mut reference_words = ArrayVec::<[_; N]>::new();
+            let mut reference_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 let words = reference_compression(
                     &inputs[i][..length],
@@ -463,11 +463,11 @@ mod test {
                 reference_words.push(words);
             }
 
-            let mut test_words = ArrayVec::<[_; N]>::new();
+            let mut test_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 test_words.push(initial_test_words(i));
             }
-            let mut jobs = ArrayVec::<[_; N]>::new();
+            let mut jobs = ArrayVec::<_, N>::new();
             for (i, words) in test_words.iter_mut().enumerate() {
                 jobs.push(Job {
                     input: &inputs[i][..length],
@@ -509,13 +509,13 @@ mod test {
 
         let mut input_buffer = [0; 100 * BLOCKBYTES];
         paint_test_input(&mut input_buffer);
-        let mut inputs = ArrayVec::<[_; N]>::new();
+        let mut inputs = ArrayVec::<_, N>::new();
         for i in 0..N {
             inputs.push(&input_buffer[i..]);
         }
 
         exercise_cases(|stride, length, last_node, finalize, count| {
-            let mut reference_words = ArrayVec::<[_; N]>::new();
+            let mut reference_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 let words = reference_compression(
                     &inputs[i][..length],
@@ -528,11 +528,11 @@ mod test {
                 reference_words.push(words);
             }
 
-            let mut test_words = ArrayVec::<[_; N]>::new();
+            let mut test_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 test_words.push(initial_test_words(i));
             }
-            let mut jobs = ArrayVec::<[_; N]>::new();
+            let mut jobs = ArrayVec::<_, N>::new();
             for (i, words) in test_words.iter_mut().enumerate() {
                 jobs.push(Job {
                     input: &inputs[i][..length],

--- a/blake2b/src/lib.rs
+++ b/blake2b/src/lib.rs
@@ -574,7 +574,7 @@ impl Default for State {
     }
 }
 
-type HexString = arrayvec::ArrayString<[u8; 2 * OUTBYTES]>;
+type HexString = arrayvec::ArrayString<{ 2 * OUTBYTES }>;
 
 /// A finalized BLAKE2 hash, with constant-time equality.
 #[derive(Clone, Copy)]
@@ -600,7 +600,7 @@ impl Hash {
     }
 
     /// Convert the hash to a lowercase hexadecimal
-    /// [`ArrayString`](https://docs.rs/arrayvec/0.4/arrayvec/struct.ArrayString.html).
+    /// [`ArrayString`](https://docs.rs/arrayvec/0.7/arrayvec/struct.ArrayString.html).
     pub fn to_hex(&self) -> HexString {
         bytes_to_hex(self.as_bytes())
     }

--- a/blake2b/src/many.rs
+++ b/blake2b/src/many.rs
@@ -93,7 +93,7 @@ pub fn degree() -> usize {
     guts::Implementation::detect().degree()
 }
 
-type JobsVec<'a, 'b> = ArrayVec<[Job<'a, 'b>; guts::MAX_DEGREE]>;
+type JobsVec<'a, 'b> = ArrayVec<Job<'a, 'b>, { guts::MAX_DEGREE }>;
 
 #[inline(always)]
 fn fill_jobs_vec<'a, 'b>(
@@ -453,7 +453,7 @@ mod test {
                 inputs[i] = &input[..chunks * BLOCKBYTES];
             }
 
-            let mut params: ArrayVec<[Params; LEN]> = ArrayVec::new();
+            let mut params: ArrayVec<Params, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 let mut p = Params::new();
                 p.node_offset(i as u64);
@@ -464,7 +464,7 @@ mod test {
                 params.push(p);
             }
 
-            let mut jobs: ArrayVec<[HashManyJob; LEN]> = ArrayVec::new();
+            let mut jobs: ArrayVec<HashManyJob, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 jobs.push(HashManyJob::new(&params[i], inputs[i]));
             }
@@ -495,7 +495,7 @@ mod test {
                 inputs[i] = &input[..chunks * BLOCKBYTES];
             }
 
-            let mut params: ArrayVec<[Params; LEN]> = ArrayVec::new();
+            let mut params: ArrayVec<Params, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 let mut p = Params::new();
                 p.node_offset(i as u64);
@@ -506,7 +506,7 @@ mod test {
                 params.push(p);
             }
 
-            let mut states: ArrayVec<[State; LEN]> = ArrayVec::new();
+            let mut states: ArrayVec<State, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 states.push(params[i].to_state());
             }

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -16,5 +16,5 @@ std = []
 
 [dependencies]
 arrayref = "0.3.5"
-arrayvec = { version = "0.5.0", default-features = false }
+arrayvec = { version = "0.7.0", default-features = false }
 constant_time_eq = "0.1.3"

--- a/blake2s/src/blake2sp.rs
+++ b/blake2s/src/blake2sp.rs
@@ -495,7 +495,7 @@ pub(crate) mod test {
     // support of the real implementation. We need this because the official test vectors don't
     // include any inputs large enough to exercise all the branches in the buffering logic.
     fn blake2sp_reference(input: &[u8]) -> Hash {
-        let mut leaves = arrayvec::ArrayVec::<[_; DEGREE]>::new();
+        let mut leaves = arrayvec::ArrayVec::<_, DEGREE>::new();
         for leaf_index in 0..DEGREE {
             leaves.push(
                 crate::Params::new()

--- a/blake2s/src/guts.rs
+++ b/blake2s/src/guts.rs
@@ -441,13 +441,13 @@ mod test {
 
         let mut input_buffer = [0; 100 * BLOCKBYTES];
         paint_test_input(&mut input_buffer);
-        let mut inputs = ArrayVec::<[_; N]>::new();
+        let mut inputs = ArrayVec::<_, N>::new();
         for i in 0..N {
             inputs.push(&input_buffer[i..]);
         }
 
         exercise_cases(|stride, length, last_node, finalize, count| {
-            let mut reference_words = ArrayVec::<[_; N]>::new();
+            let mut reference_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 let words = reference_compression(
                     &inputs[i][..length],
@@ -460,11 +460,11 @@ mod test {
                 reference_words.push(words);
             }
 
-            let mut test_words = ArrayVec::<[_; N]>::new();
+            let mut test_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 test_words.push(initial_test_words(i));
             }
-            let mut jobs = ArrayVec::<[_; N]>::new();
+            let mut jobs = ArrayVec::<_, N>::new();
             for (i, words) in test_words.iter_mut().enumerate() {
                 jobs.push(Job {
                     input: &inputs[i][..length],
@@ -506,13 +506,13 @@ mod test {
 
         let mut input_buffer = [0; 100 * BLOCKBYTES];
         paint_test_input(&mut input_buffer);
-        let mut inputs = ArrayVec::<[_; N]>::new();
+        let mut inputs = ArrayVec::<_, N>::new();
         for i in 0..N {
             inputs.push(&input_buffer[i..]);
         }
 
         exercise_cases(|stride, length, last_node, finalize, count| {
-            let mut reference_words = ArrayVec::<[_; N]>::new();
+            let mut reference_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 let words = reference_compression(
                     &inputs[i][..length],
@@ -525,11 +525,11 @@ mod test {
                 reference_words.push(words);
             }
 
-            let mut test_words = ArrayVec::<[_; N]>::new();
+            let mut test_words = ArrayVec::<_, N>::new();
             for i in 0..N {
                 test_words.push(initial_test_words(i));
             }
-            let mut jobs = ArrayVec::<[_; N]>::new();
+            let mut jobs = ArrayVec::<_, N>::new();
             for (i, words) in test_words.iter_mut().enumerate() {
                 jobs.push(Job {
                     input: &inputs[i][..length],

--- a/blake2s/src/lib.rs
+++ b/blake2s/src/lib.rs
@@ -566,7 +566,7 @@ impl Default for State {
     }
 }
 
-type HexString = arrayvec::ArrayString<[u8; 2 * OUTBYTES]>;
+type HexString = arrayvec::ArrayString<{ 2 * OUTBYTES }>;
 
 /// A finalized BLAKE2 hash, with constant-time equality.
 #[derive(Clone, Copy)]
@@ -592,7 +592,7 @@ impl Hash {
     }
 
     /// Convert the hash to a lowercase hexadecimal
-    /// [`ArrayString`](https://docs.rs/arrayvec/0.4/arrayvec/struct.ArrayString.html).
+    /// [`ArrayString`](https://docs.rs/arrayvec/0.7/arrayvec/struct.ArrayString.html).
     pub fn to_hex(&self) -> HexString {
         bytes_to_hex(self.as_bytes())
     }

--- a/blake2s/src/many.rs
+++ b/blake2s/src/many.rs
@@ -93,7 +93,7 @@ pub fn degree() -> usize {
     guts::Implementation::detect().degree()
 }
 
-type JobsVec<'a, 'b> = ArrayVec<[Job<'a, 'b>; guts::MAX_DEGREE]>;
+type JobsVec<'a, 'b> = ArrayVec<Job<'a, 'b>, { guts::MAX_DEGREE }>;
 
 #[inline(always)]
 fn fill_jobs_vec<'a, 'b>(
@@ -453,7 +453,7 @@ mod test {
                 inputs[i] = &input[..chunks * BLOCKBYTES];
             }
 
-            let mut params: ArrayVec<[Params; LEN]> = ArrayVec::new();
+            let mut params: ArrayVec<Params, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 let mut p = Params::new();
                 p.node_offset(i as u64);
@@ -464,7 +464,7 @@ mod test {
                 params.push(p);
             }
 
-            let mut jobs: ArrayVec<[HashManyJob; LEN]> = ArrayVec::new();
+            let mut jobs: ArrayVec<HashManyJob, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 jobs.push(HashManyJob::new(&params[i], inputs[i]));
             }
@@ -495,7 +495,7 @@ mod test {
                 inputs[i] = &input[..chunks * BLOCKBYTES];
             }
 
-            let mut params: ArrayVec<[Params; LEN]> = ArrayVec::new();
+            let mut params: ArrayVec<Params, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 let mut p = Params::new();
                 p.node_offset(i as u64);
@@ -506,7 +506,7 @@ mod test {
                 params.push(p);
             }
 
-            let mut states: ArrayVec<[State; LEN]> = ArrayVec::new();
+            let mut states: ArrayVec<State, LEN> = ArrayVec::new();
             for i in 0..LEN {
                 states.push(params[i].to_state());
             }

--- a/tests/fuzz_many.rs
+++ b/tests/fuzz_many.rs
@@ -41,14 +41,14 @@ fn with_random_inputs_blake2b(mut f: impl FnMut(&[blake2b_simd::Params], &[&[u8]
         // Select a random number of random length input slices from the
         // buffers.
         let num_inputs: usize = rng.gen_range(0, BLAKE2B_MAX_N + 1);
-        let mut inputs = ArrayVec::<[&[u8]; BLAKE2B_MAX_N]>::new();
+        let mut inputs = ArrayVec::<&[u8], BLAKE2B_MAX_N>::new();
         for i in 0..num_inputs {
             let input_length = rng.gen_range(0, BLAKE2B_MAX_LEN + 1);
             inputs.push(&input_bufs[i][..input_length]);
         }
 
         // For each input slice, create a random Params object.
-        let mut params = ArrayVec::<[blake2b_simd::Params; BLAKE2B_MAX_N]>::new();
+        let mut params = ArrayVec::<blake2b_simd::Params, BLAKE2B_MAX_N>::new();
         for _ in 0..num_inputs {
             params.push(random_params_blake2b(&mut rng));
         }
@@ -61,14 +61,14 @@ fn with_random_inputs_blake2b(mut f: impl FnMut(&[blake2b_simd::Params], &[&[u8]
 fn fuzz_blake2b_hash_many() {
     with_random_inputs_blake2b(|params, inputs| {
         // Compute the hash of each input independently.
-        let mut expected = ArrayVec::<[blake2b_simd::Hash; BLAKE2B_MAX_N]>::new();
+        let mut expected = ArrayVec::<blake2b_simd::Hash, BLAKE2B_MAX_N>::new();
         for (param, input) in params.iter().zip(inputs.iter()) {
             expected.push(param.hash(input));
         }
 
         // Now compute the same hashes in a batch, and check that this gives
         // the same result.
-        let mut jobs: ArrayVec<[blake2b_simd::many::HashManyJob; BLAKE2B_MAX_N]> = inputs
+        let mut jobs: ArrayVec<blake2b_simd::many::HashManyJob, BLAKE2B_MAX_N> = inputs
             .iter()
             .zip(params.iter())
             .map(|(input, param)| blake2b_simd::many::HashManyJob::new(param, input))
@@ -85,7 +85,7 @@ fn fuzz_blake2b_update_many() {
     with_random_inputs_blake2b(|params, inputs| {
         // Compute the hash of each input independently. Feed each into the
         // state twice, to exercise buffering.
-        let mut expected = ArrayVec::<[blake2b_simd::Hash; BLAKE2B_MAX_N]>::new();
+        let mut expected = ArrayVec::<blake2b_simd::Hash, BLAKE2B_MAX_N>::new();
         for (param, input) in params.iter().zip(inputs.iter()) {
             let mut state = param.to_state();
             state.update(input);
@@ -95,7 +95,7 @@ fn fuzz_blake2b_update_many() {
 
         // Now compute the same hashes in a batch, and check that this gives
         // the same result.
-        let mut states = ArrayVec::<[blake2b_simd::State; BLAKE2B_MAX_N]>::new();
+        let mut states = ArrayVec::<blake2b_simd::State, BLAKE2B_MAX_N>::new();
         for param in params {
             states.push(param.to_state());
         }
@@ -140,14 +140,14 @@ fn with_random_inputs_blake2s(mut f: impl FnMut(&[blake2s_simd::Params], &[&[u8]
         // Select a random number of random length input slices from the
         // buffers.
         let num_inputs: usize = rng.gen_range(0, BLAKE2S_MAX_N + 1);
-        let mut inputs = ArrayVec::<[&[u8]; BLAKE2S_MAX_N]>::new();
+        let mut inputs = ArrayVec::<&[u8], BLAKE2S_MAX_N>::new();
         for i in 0..num_inputs {
             let input_length = rng.gen_range(0, BLAKE2S_MAX_LEN + 1);
             inputs.push(&input_bufs[i][..input_length]);
         }
 
         // For each input slice, create a random Params object.
-        let mut params = ArrayVec::<[blake2s_simd::Params; BLAKE2S_MAX_N]>::new();
+        let mut params = ArrayVec::<blake2s_simd::Params, BLAKE2S_MAX_N>::new();
         for _ in 0..num_inputs {
             params.push(random_params_blake2s(&mut rng));
         }
@@ -160,14 +160,14 @@ fn with_random_inputs_blake2s(mut f: impl FnMut(&[blake2s_simd::Params], &[&[u8]
 fn fuzz_blake2s_hash_many() {
     with_random_inputs_blake2s(|params, inputs| {
         // Compute the hash of each input independently.
-        let mut expected = ArrayVec::<[blake2s_simd::Hash; BLAKE2S_MAX_N]>::new();
+        let mut expected = ArrayVec::<blake2s_simd::Hash, BLAKE2S_MAX_N>::new();
         for (param, input) in params.iter().zip(inputs.iter()) {
             expected.push(param.hash(input));
         }
 
         // Now compute the same hashes in a batch, and check that this gives
         // the same result.
-        let mut jobs: ArrayVec<[blake2s_simd::many::HashManyJob; BLAKE2S_MAX_N]> = inputs
+        let mut jobs: ArrayVec<blake2s_simd::many::HashManyJob, BLAKE2S_MAX_N> = inputs
             .iter()
             .zip(params.iter())
             .map(|(input, param)| blake2s_simd::many::HashManyJob::new(param, input))
@@ -184,7 +184,7 @@ fn fuzz_blake2s_update_many() {
     with_random_inputs_blake2s(|params, inputs| {
         // Compute the hash of each input independently. Feed each into the
         // state twice, to exercise buffering.
-        let mut expected = ArrayVec::<[blake2s_simd::Hash; BLAKE2S_MAX_N]>::new();
+        let mut expected = ArrayVec::<blake2s_simd::Hash, BLAKE2S_MAX_N>::new();
         for (param, input) in params.iter().zip(inputs.iter()) {
             let mut state = param.to_state();
             state.update(input);
@@ -194,7 +194,7 @@ fn fuzz_blake2s_update_many() {
 
         // Now compute the same hashes in a batch, and check that this gives
         // the same result.
-        let mut states = ArrayVec::<[blake2s_simd::State; BLAKE2S_MAX_N]>::new();
+        let mut states = ArrayVec::<blake2s_simd::State, BLAKE2S_MAX_N>::new();
         for param in params {
             states.push(param.to_state());
         }


### PR DESCRIPTION
In spite of the large diff, this is a fairly small actual change:
just use arrayvec 0.7 everywhere and instead of using the array parameter, use <T, const N: usize> parameters.

Bench difference appears to be largely negligible, with an admittedly notable hit on two benches and an explosive improvement on bench_long_blake2sp! No idea why! But I use an AMD processor and did not exhaustively bench and profile this, I just ran it a few times on each to make sure the diffs were roughly constant, so please feel free to do your own review.
```
 name                             main-all.txt ns/iter  branch-all.txt ns/iter   diff ns/iter   diff %  speedup
 bench_long_blake2b_avx2          43,285 (1514 MB/s)    43,280 (1514 MB/s)                 -5   -0.01%   x 1.00
 bench_long_blake2b_many_2x       59,737 (2194 MB/s)    59,750 (2193 MB/s)                 13    0.02%   x 1.00
 bench_long_blake2b_many_4x       65,285 (4015 MB/s)    70,791 (3703 MB/s)              5,506    8.43%   x 0.92
 bench_long_blake2b_portable      49,335 (1328 MB/s)    49,820 (1315 MB/s)                485    0.98%   x 0.99
 bench_long_blake2bp              16,564 (3956 MB/s)    17,854 (3670 MB/s)              1,290    7.79%   x 0.93
 bench_long_blake2s_many_4x       108,650 (2412 MB/s)   108,450 (2417 MB/s)              -200   -0.18%   x 1.00
 bench_long_blake2s_many_8x       123,798 (4235 MB/s)   121,030 (4331 MB/s)            -2,768   -2.24%   x 1.02
 bench_long_blake2s_portable      82,352 (795 MB/s)     82,782 (791 MB/s)                 430    0.52%   x 0.99
 bench_long_blake2s_sse41         68,866 (951 MB/s)     68,767 (953 MB/s)                 -99   -0.14%   x 1.00
 bench_long_blake2sp              32,954 (1988 MB/s)    15,509 (4225 MB/s)            -17,445  -52.94%   x 2.12
 bench_oneblock_blake2b_avx2      94 (1361 MB/s)        95 (1347 MB/s)                      1    1.06%   x 0.99
 bench_oneblock_blake2b_many_2x   197 (1299 MB/s)       190 (1347 MB/s)                    -7   -3.55%   x 1.04
 bench_oneblock_blake2b_many_4x   239 (2142 MB/s)       232 (2206 MB/s)                    -7   -2.93%   x 1.03
 bench_oneblock_blake2b_portable  110 (1163 MB/s)       110 (1163 MB/s)                     0    0.00%   x 1.00
 bench_oneblock_blake2s_many_4x   219 (1168 MB/s)       235 (1089 MB/s)                    16    7.31%   x 0.93
 bench_oneblock_blake2s_many_8x   291 (1759 MB/s)       286 (1790 MB/s)                    -5   -1.72%   x 1.02
 bench_oneblock_blake2s_portable  93 (688 MB/s)         93 (688 MB/s)                       0    0.00%   x 1.00
 bench_oneblock_blake2s_sse41     64 (1000 MB/s)        64 (1000 MB/s)                      0    0.00%   x 1.00
 bench_onebyte_blake2b_avx2       101                   101                                 0    0.00%   x 1.00
 bench_onebyte_blake2s_sse41      80                    80                                  0    0.00%   x 1.00
```