### PR TITLE
Bump `constant-time-eq` to version 0.2.4

### DIFF
--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -22,4 +22,4 @@ uninline_portable = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.1.3"
+constant_time_eq = "0.2.4"

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -17,4 +17,4 @@ std = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.1.3"
+constant_time_eq = "0.2.4"


### PR DESCRIPTION
Hi! We use this library in the [`uutils`](https://github.com/uutils/coreutils) project and we try to be mindful of (transitive) dependencies that appear with different versions in our dependency graph. One of these dependencies is `constant-time-eq`, so I figured I'd make a PR to bump it.

As far as I can tell, there seems to have been no significant change in the API from 0.1.3 to 0.2.4, so I think it should be safe to update. However, they have set the MSRV to 1.59, so if you want to support earlier Rust versions, you might want to close this PR.