### PR TITLE
Bump constant_time_eq to 0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           # https://github.com/rust-lang/libs-team/issues/72.
           # This test target is here so that we notice if we accidentally bump
           # the MSRV, but it's not a promise that we won't bump it.
-          "1.59.0",
+          "1.66.0",
         ]
 
     steps:

--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -22,4 +22,4 @@ uninline_portable = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.2.4"
+constant_time_eq = "0.3.0"

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -17,4 +17,4 @@ std = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.2.4"
+constant_time_eq = "0.3.0"


### PR DESCRIPTION
rust-argon2 switched already now users have two copies of constant_time_eq in their dependency tree.