### PR TITLE
Add powerpc64le target to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           - i686-unknown-linux-musl
           - armv7-unknown-linux-gnueabihf
           - aarch64-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
           # Big-endian targets. See https://twitter.com/burntsushi5/status/1695483429997945092.
           - powerpc64-unknown-linux-gnu
           - s390x-unknown-linux-gnu


### PR DESCRIPTION
Since we have tested against the Big Endian version, I think we should also cover the Little Endian version too