### PR TITLE
Update constant_time_eq from 0.3.0 to 0.4.2

### DIFF
--- a/blake2b/Cargo.toml
+++ b/blake2b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = []
+std = ["constant_time_eq/std"]
 # This crate does a lot of #[inline(always)]. For BLAKE2b on ARM Cortex-M0 (and
 # presumably other tiny chips), some of that inlining actually hurts
 # performance. This feature disables some inlining, improving the performance
@@ -22,4 +22,4 @@ uninline_portable = []
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.3.0"
+constant_time_eq = { version = "0.4.2", default-features = false }

--- a/blake2s/Cargo.toml
+++ b/blake2s/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2021"
 
 [features]
 default = ["std"]
-std = []
+std = ["constant_time_eq/std"]
 
 [dependencies]
 arrayref = "0.3.5"
 arrayvec = { version = "0.7.0", default-features = false }
-constant_time_eq = "0.3.0"
+constant_time_eq = { version = "0.4.2", default-features = false }


### PR DESCRIPTION
Since 0.4, the `constant_time_eq` has a default-enabled `std` feature, just like the ones in these crates. I believe I’ve handled this change correctly by disabling default features for `constant_time_eq` and tying its `std` feature to the `std` features in `blake2b`/`blake2s`.

Changelog: https://github.com/cesarb/constant_time_eq/blob/0.4.2/CHANGES
Source diff: https://github.com/cesarb/constant_time_eq/compare/0.3.1...0.4.2